### PR TITLE
Feature/fix log4j2 usage

### DIFF
--- a/src/main/java/ch/unibas/dmi/dbis/vrem/importer/DemoImporter.java
+++ b/src/main/java/ch/unibas/dmi/dbis/vrem/importer/DemoImporter.java
@@ -41,7 +41,7 @@ public class DemoImporter implements Runnable {
 
 
 
-    public static final Logger LOGGER = LogManager.getLogger();
+    public static final Logger LOGGER = LogManager.getLogger(DemoImporter.class);
 
     public static final String FIELD_NAME_IMAGE = "\uFEFFBildcode";
     public static final String FIELD_NAME_OBJECT_NUMBER = "Inventarnummer";

--- a/src/main/java/ch/unibas/dmi/dbis/vrem/importer/ExhibitionImporter.java
+++ b/src/main/java/ch/unibas/dmi/dbis/vrem/importer/ExhibitionImporter.java
@@ -59,7 +59,7 @@ import spark.utils.StringUtils;
 @Command(name = "import-folder", description = "Imports a folder-based exhibition")
 public class ExhibitionImporter implements Runnable {
 
-    private static final Logger LOGGER = LogManager.getLogger();
+    private static final Logger LOGGER = LogManager.getLogger(ExhibitionImporter.class.getName());
 
     public static final String NORTH_WALL_NAME = "north";
     public static final String EAST_WALL_NAME = "east";

--- a/src/main/java/ch/unibas/dmi/dbis/vrem/importer/ExhibitionImporter.java
+++ b/src/main/java/ch/unibas/dmi/dbis/vrem/importer/ExhibitionImporter.java
@@ -59,7 +59,7 @@ import spark.utils.StringUtils;
 @Command(name = "import-folder", description = "Imports a folder-based exhibition")
 public class ExhibitionImporter implements Runnable {
 
-    private static final Logger LOGGER = LogManager.getLogger(ExhibitionImporter.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(ExhibitionImporter.class);
 
     public static final String NORTH_WALL_NAME = "north";
     public static final String EAST_WALL_NAME = "east";

--- a/src/main/java/ch/unibas/dmi/dbis/vrem/server/handlers/exhibition/LoadExhibitionHandler.java
+++ b/src/main/java/ch/unibas/dmi/dbis/vrem/server/handlers/exhibition/LoadExhibitionHandler.java
@@ -13,7 +13,7 @@ public class LoadExhibitionHandler extends ParsingActionHandler<Exhibition> {
 
     private final static String ATTRIBUTE_ID = ":id";
 
-    private final static Logger LOGGER = LogManager.getLogger();
+    private final static Logger LOGGER = LogManager.getLogger(LoadExhibitionHandler.class);
 
     public LoadExhibitionHandler(VREMReader reader) {
         this.reader = reader;

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration name="CoreConfig" status="INFO">
   <Properties>
-    <Property name="loggingPattern">[%d{HH:mm:ss.SSS}][%-5level][%t] %C{1} - %msg%n</Property>
+    <Property name="loggingPattern">[%d{HH:mm:ss.SSS}][%-5level][%t] %c{2} - %msg%n</Property>
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">


### PR DESCRIPTION
Fixes usage of getCaller - a feature which is not supported out-of-the-box any more.
Using the fully quallified class name for loggers and adjusting the logging pattern to use the logger name, everybody is happy again.