### PR TITLE
Decompose mongodb id and human readable

### DIFF
--- a/src/main/java/ch/unibas/dmi/dbis/vrem/database/codec/ExhibitionCodec.java
+++ b/src/main/java/ch/unibas/dmi/dbis/vrem/database/codec/ExhibitionCodec.java
@@ -1,8 +1,7 @@
 package ch.unibas.dmi.dbis.vrem.database.codec;
 
-import ch.unibas.dmi.dbis.vrem.model.Vector3f;
-import ch.unibas.dmi.dbis.vrem.model.exhibition.*;
-
+import ch.unibas.dmi.dbis.vrem.model.exhibition.Exhibition;
+import ch.unibas.dmi.dbis.vrem.model.exhibition.Room;
 import org.bson.BsonReader;
 import org.bson.BsonType;
 import org.bson.BsonWriter;
@@ -18,10 +17,11 @@ import java.util.List;
 
 public class ExhibitionCodec implements Codec<Exhibition> {
 
-    public final String FIELD_NAME_ID = "_id";
-    public final String FIELD_NAME_TEXT = "name";
-    public final String FIELD_NAME_DESCRIPTION = "description";
-    public final String FIELD_NAME_ROOMS = "rooms";
+    public static final String FIELD_NAME_ID = "_id";
+    public static final String FIELD_NAME_KEY = "key";
+    public static final String FIELD_NAME_TEXT = "name";
+    public static final String FIELD_NAME_DESCRIPTION = "description";
+    public static final String FIELD_NAME_ROOMS = "rooms";
 
     private final Codec<Room> codec;
 
@@ -32,21 +32,25 @@ public class ExhibitionCodec implements Codec<Exhibition> {
     @Override
     public Exhibition decode(BsonReader reader, DecoderContext decoderContext) {
         reader.readStartDocument();
-        String id = null;
+        ObjectId id = null;
         String name = null;
         String description = null;
+        String key = null;
         List<Room> rooms = new LinkedList<>();
 
-        while(reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+        while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
             switch (reader.readName()) {
                 case FIELD_NAME_ID:
-                    id = reader.readString();
+                    id = reader.readObjectId();
                     break;
                 case FIELD_NAME_TEXT:
                     name = reader.readString();
                     break;
                 case FIELD_NAME_DESCRIPTION:
                     description = reader.readString();
+                    break;
+                case FIELD_NAME_KEY:
+                    key = reader.readString();
                     break;
                 case FIELD_NAME_ROOMS:
                     reader.readStartArray();
@@ -61,7 +65,7 @@ public class ExhibitionCodec implements Codec<Exhibition> {
             }
         }
         reader.readEndDocument();
-        final Exhibition exhibition = new Exhibition(id, name, description);
+        final Exhibition exhibition = new Exhibition(id, key, name, description);
         for (Room room : rooms) {
             exhibition.addRoom(room);
         }
@@ -71,15 +75,16 @@ public class ExhibitionCodec implements Codec<Exhibition> {
     @Override
     public void encode(BsonWriter writer, Exhibition value, EncoderContext encoderContext) {
         writer.writeStartDocument();
-            writer.writeString(FIELD_NAME_ID, value.id);
-            writer.writeString(FIELD_NAME_TEXT, value.name);
-            writer.writeString(FIELD_NAME_DESCRIPTION, value.description);
-            writer.writeName(FIELD_NAME_ROOMS);
-            writer.writeStartArray();
-            for (Room room : value.getRooms()) {
-                this.codec.encode(writer, room, encoderContext);
-            }
-            writer.writeEndArray();
+        writer.writeObjectId(FIELD_NAME_ID, value.id);
+        writer.writeString(FIELD_NAME_KEY, value.key);
+        writer.writeString(FIELD_NAME_TEXT, value.name);
+        writer.writeString(FIELD_NAME_DESCRIPTION, value.description);
+        writer.writeName(FIELD_NAME_ROOMS);
+        writer.writeStartArray();
+        for (Room room : value.getRooms()) {
+            this.codec.encode(writer, room, encoderContext);
+        }
+        writer.writeEndArray();
         writer.writeEndDocument();
     }
 

--- a/src/main/java/ch/unibas/dmi/dbis/vrem/database/dao/VREMReader.java
+++ b/src/main/java/ch/unibas/dmi/dbis/vrem/database/dao/VREMReader.java
@@ -1,5 +1,6 @@
 package ch.unibas.dmi.dbis.vrem.database.dao;
 
+import ch.unibas.dmi.dbis.vrem.database.codec.ExhibitionCodec;
 import ch.unibas.dmi.dbis.vrem.model.exhibition.Exhibit;
 import ch.unibas.dmi.dbis.vrem.model.exhibition.Exhibition;
 
@@ -31,12 +32,16 @@ public class VREMReader extends VREMDao {
      * @return
      */
     public Exhibition getExhibition(ObjectId id) {
-        return getExhibition(id.toString());
+        return getExhibition(ExhibitionCodec.FIELD_NAME_ID, id);
     }
 
-    public Exhibition getExhibition(String id){
+    public Exhibition getExhibition(String key){
+        return getExhibition(ExhibitionCodec.FIELD_NAME_KEY, key);
+    }
+
+    private Exhibition getExhibition(String fieldName, Object key){
         final MongoCollection<Exhibition> exhibitions = this.database.getCollection(EXHIBITION_COLLECTION, Exhibition.class);
-        return exhibitions.find(Filters.eq("_id",id)).first();
+        return exhibitions.find(Filters.eq(fieldName,key)).first();
     }
 
     /**

--- a/src/main/java/ch/unibas/dmi/dbis/vrem/importer/ExhibitionImporter.java
+++ b/src/main/java/ch/unibas/dmi/dbis/vrem/importer/ExhibitionImporter.java
@@ -97,8 +97,8 @@ public class ExhibitionImporter implements Runnable {
     @Option(title = "Exhibition-Description", name = {"--description"}, description = "Description of the exhibition to be imported")
     private String exhibitionDescription = "";
 
-    @Option(title = "Exhibition-ID", name = {"--id"}, description = "ID of the exhibition to be imported")
-    private String id = null;
+    @Option(title = "Exhibition-Key", name = {"--key"}, description = "Key of the exhibition to be imported, i.e. human readable key")
+    private String key = null;
 
     private Gson gson;
 
@@ -152,8 +152,8 @@ public class ExhibitionImporter implements Runnable {
             }
 
             Exhibition exhibition;
-            if (id != null) {
-                exhibition = new Exhibition(id, exhibitionName, exhibitionDescription);
+            if (key != null) {
+                exhibition = new Exhibition(key, exhibitionName, exhibitionDescription);
             } else {
                 exhibition = new Exhibition(exhibitionName, exhibitionDescription);
             }

--- a/src/main/java/ch/unibas/dmi/dbis/vrem/model/exhibition/Exhibition.java
+++ b/src/main/java/ch/unibas/dmi/dbis/vrem/model/exhibition/Exhibition.java
@@ -8,20 +8,23 @@ import org.bson.types.ObjectId;
 public class Exhibition {
 
 
-    public final String id;
+    public final ObjectId id;
 
     public final String name;
+
+    public final String key;
 
     public final String description;
 
     private final List<Room> rooms = new ArrayList<>();
 
     public Exhibition(ObjectId id, String name, String description) {
-        this(id.toString(), name, description);
+        this(id, name.replace(' ', '-'), name, description);
     }
 
-    public Exhibition(String id, String name, String description) {
+    public Exhibition(ObjectId id, String key, String name, String description) {
         this.id = id;
+        this.key = key;
         this.name = name;
         this.description = description;
     }
@@ -30,6 +33,9 @@ public class Exhibition {
         this(new ObjectId(), name, description);
     }
 
+    public Exhibition(String key, String name, String description){
+        this(new ObjectId(), key, name, description);
+    }
 
     public boolean addRoom(Room room) {
         if (!this.rooms.contains(room)) {

--- a/src/main/java/ch/unibas/dmi/dbis/vrem/model/exhibition/ExhibitionSummary.java
+++ b/src/main/java/ch/unibas/dmi/dbis/vrem/model/exhibition/ExhibitionSummary.java
@@ -5,6 +5,7 @@ import org.bson.types.ObjectId;
 public class ExhibitionSummary {
     public String objectId;
 
+
     public String name;
 
     /**

--- a/src/main/java/ch/unibas/dmi/dbis/vrem/server/handlers/basic/ParsingActionHandler.java
+++ b/src/main/java/ch/unibas/dmi/dbis/vrem/server/handlers/basic/ParsingActionHandler.java
@@ -1,9 +1,12 @@
 package ch.unibas.dmi.dbis.vrem.server.handlers.basic;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import com.google.gson.*;
+
+import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.bson.types.ObjectId;
 import spark.Request;
 import spark.Response;
 
@@ -28,6 +31,28 @@ public abstract class ParsingActionHandler<A> implements ActionHandler<A> {
             response.type("application/json");
 
             GsonBuilder builder = new GsonBuilder();
+            JsonSerializer<ObjectId> serializer = new JsonSerializer<ObjectId>() {
+                @Override
+                public JsonElement serialize(ObjectId src, Type typeOfSrc, JsonSerializationContext context) {
+                    JsonObject json = new JsonObject();
+                    json.addProperty("id", src.toHexString());
+                    return json;
+                }
+            };
+            JsonDeserializer<ObjectId> deserializer = new JsonDeserializer<ObjectId>() {
+                @Override
+                public ObjectId deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+                    if(json instanceof JsonObject){
+                        JsonObject obj = (JsonObject)json;
+                        return new ObjectId(obj.get("id").getAsString());
+                    }
+                    throw new JsonParseException("Couldn't parse objectId: "+json);
+                }
+            };
+
+            builder.registerTypeAdapter(ObjectId.class, serializer);
+            builder.registerTypeAdapter(ObjectId.class, deserializer);
+
             final Gson gson = builder.create();
 
             switch (request.requestMethod()) {

--- a/src/main/java/ch/unibas/dmi/dbis/vrem/server/handlers/exhibition/LoadExhibitionHandler.java
+++ b/src/main/java/ch/unibas/dmi/dbis/vrem/server/handlers/exhibition/LoadExhibitionHandler.java
@@ -6,6 +6,7 @@ import ch.unibas.dmi.dbis.vrem.server.handlers.basic.ParsingActionHandler;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.bson.types.ObjectId;
 
 public class LoadExhibitionHandler extends ParsingActionHandler<Exhibition> {
 
@@ -21,7 +22,7 @@ public class LoadExhibitionHandler extends ParsingActionHandler<Exhibition> {
 
     @Override
     public Exhibition doGet(Map<String, String> parameters) {
-        final String objectId = parameters.get(ATTRIBUTE_ID);
+        final ObjectId objectId = new ObjectId(parameters.get(ATTRIBUTE_ID));
         LOGGER.debug("Loading exhibition {}", objectId);
         Exhibition exhibition = this.reader.getExhibition(objectId);
         if (exhibition == null) {


### PR DESCRIPTION
Decomposed the mongodb generated uid from a human readable unique identifier, called `key`.
This enables users to name their exhibitions in a way they remember, and retrieve them by this key from VREP. However, VREP is not yet updated accordingly.

## Changes

 * Changed the `exhibition.id` property type from string to ObjectId
 * Custom de- / serialization for `exhibition.id`, example: `{"id":"5d4410fe999c9e67508eee45"}`
 * Added new property `exhibition.key` of type string