### PR TITLE
Updated to log4j 2.17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,6 @@ idea {
 
 repositories {
     mavenCentral()
-    maven { url "https://kotlin.bintray.com/kotlinx" }
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 javaCompatibility=11
 kotlinVersion=1.5.30
 openApiGenVersion=5.1.1
-log4jslf4jVersion=2.15.0
+log4jslf4jVersion=2.17.0
 kotlinLoggingVersion=2.1.16
 cliktVersion=2.8.0
 kotlinxSerializationVersion=1.2.2


### PR DESCRIPTION
Addressing [CVE-2021-45105](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105)